### PR TITLE
PHP Code Sniffer rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ interpreted as described in [RFC 2119](http://www.ietf.org/rfc/rfc2119.txt).
 [PSR-0]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
 [PSR-4]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md
 
-1. General
---------
+## 1. General
 
 ### 1.1. PHP Tags
 
@@ -124,8 +123,7 @@ if (! function_exists('bar')) {
 ```
 
 
-2. Namespace, Use Declarations and Class Names
-----------------------------
+## 2. Namespace, Use Declarations and Class Names
 
 - Namespaces and classes MUST follow [PSR-4] "autoloading".
   This means each class is in a file by itself, and is in a namespace of at
@@ -222,8 +220,7 @@ class ClassName extends ParentClass implements
 }
 ```
 
-3. Class Constants, Properties, and Methods
--------------------------------------------
+## 3. Class Constants, Properties, and Methods
 
 The term "class" refers to all classes, interfaces, and traits.
 
@@ -363,8 +360,7 @@ abstract class ClassName
     }
 }
 ```
-4. Method and Function Calls
-----------------------------
+## 4. Method and Function Calls
 
 - When making a method or function call, there MUST NOT be a space between the
   method or function name and the opening parenthesis, there MUST NOT be a space
@@ -391,8 +387,7 @@ $foo->bar(
     $muchLongerArgument
 );
 ```
-5. Control Structures
----------------------
+## 5. Control Structures
 
 The general style rules for control structures are as follows:
 
@@ -543,8 +538,7 @@ try {
 - There MUST be braces surrounding the condition if it contains any form of expression,
   i.e. is not simply a variable or boolean.
 
-6. Closures
------------
+## 6. Closures
 
 - Closures MUST be declared with a space after the `function` keyword, and a
   space before and after the `use` keyword.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,28 @@ interpreted as described in [RFC 2119](http://www.ietf.org/rfc/rfc2119.txt).
 [PSR-0]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
 [PSR-4]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md
 
+## PHP Code Sniffer
+
+A [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer) ruleset along with custom _sniffs_ is in the `phpcs\kentStandard` folder. This ruleset implements most, but not all, of the rules outlined below. To use this you must install [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer) and make phpcs and phpcbf avaliable on your path.
+
+This ruleset can be used on the command line and by editors such as [VS Code](https://code.visualstudio.com/) to automatically flag or fix errors.
+
+In the commands below assume that the kentStandards repo is checked out at `~/Code/kentStandards`
+
+Examples:  
+
+1. To list errors in a specific file
+
+```
+phpcs --standard=~/Code/KentStandards/phpcs/kentStandard/ruleset.xml file.php
+```
+
+2. To fix errors in a specific file when possible
+
+```
+phpcbf --standard=~/Code/KentStandards/phpcs/kentStandard/ruleset.xml file.php
+```
+
 ## 1. General
 
 ### 1.1. PHP Tags

--- a/phpcs/kent-coding-standard.xml
+++ b/phpcs/kent-coding-standard.xml
@@ -12,13 +12,11 @@ corrections to help it match the standard are more than welcome
 
 <!-- 1.1. PHP Tags
 PHP code MUST use the long <?php ?> tags it MUST NOT use the short-echo <?= ?> tags or other tag variations. 
-
 @TODO - need custom config
 -->
 
 <!-- 1.2. Character Encoding
 PHP code MUST use only UTF-8 without BOM.
-
 @TODO - need custom config
 -->
 
@@ -30,33 +28,26 @@ SAME AS PSR2
 
 
 <!-- 1.4. Whitespace & Indentation
-
 All PHP files MUST end with a single blank line.
-
 SAME AS PSR2
--->
 
-<!-- 
+
 The closing ?> tag MUST be omitted from files containing only PHP.
-
 SAME AS PSR2
--->
 
-<!-- 
+
 There MUST NOT be trailing whitespace at the end of non-blank lines.
-
 SAME AS PSR2
--->
 
-<!-- 
+
 Single blank lines MAY be added to improve readability and to indicate related blocks of code.
 SAME AS PSR2
--->
 
-<!--
+
 Code MUST use tabs for indentation, and MUST NOT use spaces for indenting.
 The use of spaces is permitted for fine-grained inter-line alignment of operators, values etc.
-Kent Rule
+@TODO - Kent Rule - need custom config??
+
 -->
 <rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
 </ruleset>
@@ -64,15 +55,17 @@ Kent Rule
 
 
 <!--  1.5. Lines
-
 There MUST NOT be more than one statement per line.
 SAME AS PSR2
+
 
 There MUST NOT be a hard limit on line length.
 SAME AS PSR2
 
+
 The soft limit on line length MUST be 120 characters; automated style checkers MUST warn but MUST NOT error at the soft limit.
 SAME AS PSR2
+
 
 Lines SHOULD NOT be longer than 80 characters; lines longer than that SHOULD be split into multiple subsequent lines of no more than 80 characters each.
 SAME AS PSR2
@@ -80,7 +73,6 @@ SAME AS PSR2
 
 
 <!-- 1.6. Keywords and True/False/Null
-
 PHP keywords MUST be in lower case.
 SAME AS PSR2
 
@@ -94,17 +86,364 @@ or it SHOULD execute logic with side effects, but SHOULD NOT do both.
 SAME AS PSR2 (defined in PSR1) 
 -->
 
-
-
-<!--  Namespace, Use Declarations and Class Names
+<!--  2 Namespace, Use Declarations and Class Names
 Namespaces and classes MUST follow PSR-4 "autoloading". This means each class is in a file by itself, 
 and is in a namespace of at least one level: a top-level vendor name.
+@TODO - Kent Rule - need custom config??
+
 
 When present, there MUST be one blank line after the namespace declaration.
+SAME AS PSR2 
+
 
 When present, all use declarations MUST go after the namespace declaration.
+SAME AS PSR2
+
 
 There MUST be one use keyword per declaration.
+SAME AS PSR2
+
 
 There MUST be one blank line after the use block.
+SAME AS PSR2
+
+Class names MUST be declared in StudlyCaps.
+SAME AS PSR2 (defined in PSR1)
+
+
+Code written for PHP 5.3 and after MUST use formal namespaces.
+SAME AS PSR2 (defined in PSR1)
+
+
+Code written for 5.2.x and before SHOULD use the pseudo-namespacing convention of Vendor_ prefixes on class names.
+@TODO - Kent Rule - need custom config??
+
+The extends and implements keywords MUST be declared on the same line as the class name.
+SAME AS PSR2
+
+
+The opening brace for the class MUST go on its own line; the closing brace for the class MUST go on the next line after the body.
+SAME AS PSR2
+
+Lists of implements MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one interface per line.
+SAME AS PSR2
+-->
+
+<!-- 3 Class Constants, Properties, and Methods 
+3.1. Constants
+
+Class constants MUST be declared in all upper case with underscore separators
+SAME AS PSR2 (defined in PSR1)
+-->
+
+<!--
+3.2. Properties
+
+Properties and Variables MUST use an underscore format. For example $variable_name.
+@TODO - Kent Rule - need custom config??
+
+
+Visibility MUST be declared on all properties.
+SAME AS PSR2
+
+
+The var keyword MUST NOT be used to declare a property.
+SAME AS PSR2
+
+
+Method names SHOULD NOT be prefixed with a single underscore to indicate protected or private visibility.
+SAME AS PSR2
+
+
+Method names MUST NOT be declared with a space after the method name. The opening brace MUST go on its own line, and the closing brace MUST go on the next line following the body. There MUST NOT be a space after the opening parenthesis, and there MUST NOT be a space before the closing parenthesis.
+SAME AS PSR2
+
+
+- A method declaration looks like the following. Note the placement of
+  parentheses, commas, spaces, and braces:
+
+```php
+<?php
+namespace Vendor\Package;
+
+class ClassName
+{
+    public function fooBarBaz($arg1, &$arg2, $arg3 = [])
+    {
+        // method body
+    }
+}
+```
+SAME AS PSR2
+
+In the argument list, there MUST NOT be a space before each comma, and there MUST be one space after each comma.
+SAME AS PSR2
+
+
+Method arguments with default values MUST go at the end of the argument list.
+SAME AS PSR2
+
+
+Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line.
+SAME AS PSR2
+
+
+When the argument list is split across multiple lines, the closing parenthesis and opening brace MUST be placed together on their own line with one space between them.
+SAME AS PSR2
+-->
+
+<!-- 3.4. abstract, final, and static
+
+When present, the abstract and final declarations MUST precede the visibility declaration.
+SAME AS PSR2
+
+
+When present, the static declaration MUST come after the visibility declaration.
+SAME AS PSR2
+-->
+
+<!-- 4. Method and Function Calls
+
+When making a method or function call, there MUST NOT be a space between the method or function name and the opening parenthesis, there MUST NOT be a space after the opening parenthesis, and there MUST NOT be a space before the closing parenthesis. In the argument list, there MUST NOT be a space before each comma, and there MUST be one space after each comma.
+SAME AS PSR2
+
+
+Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line.
+SAME AS PSR2
+-->
+
+<!-- 5. Control Structures
+
+The general style rules for control structures are as follows:
+
+- There MUST be one space after the control structure keyword
+SAME AS PSR2
+
+
+- There MUST NOT be a space after the opening parenthesis
+SAME AS PSR2
+
+
+- There MUST NOT be a space before the closing parenthesis
+SAME AS PSR2
+
+
+- There MUST be one space between the closing parenthesis and the opening
+  brace
+SAME AS PSR2
+
+
+- The structure body MUST be indented once
+SAME AS PSR2
+
+- The closing brace MUST be on the next line after the body
+SAME AS PSR2
+
+
+- The body of each structure MUST be enclosed by braces. This standardizes how
+  the structures look, and reduces the likelihood of introducing errors as new
+  lines get added to the body.
+SAME AS PSR2
+
+
+- Colon notation MUST NOT be used. I.E :
+```php
+if(true) :  
+  //stuff here
+endif;
+```
+SAME AS PSR2 - or at least this is just an explaination of the 'enclosed by braces' rule above this
+-->
+
+<!-- 5.1. if, elseif, else if, else
+
+An if structure looks like the following. Note the placement of parentheses, spaces, and braces; and that else and elseif or else if are on the same line as the closing brace from the earlier body.
+
+```php
+<?php
+if ($expr1) {
+    // if body
+} elseif ($expr2) {
+    // elseif body
+} else {
+    // else body;
+}
+SAME AS PSR2
+
+
+The keyword elseif SHOULD be used instead of else if so that all control keywords look like single words.
+SAME AS PSR2
+-->
+
+<!-- 5.2. switch, case
+
+A switch structure looks like the following. Note the placement of parentheses, spaces, and braces. The case statement MUST be indented once from switch, and the break keyword (or other terminating keyword) MUST be indented at the same level as the case body. There MUST be a comment such as // no break when fall-through is intentional in a non-empty case body.
+
+<?php
+switch ($expr) {
+    case 0:
+        echo 'First case, with a break';
+        break;
+    case 1:
+        echo 'Second case, which falls through';
+        // no break
+    case 2:
+    case 3:
+    case 4:
+        echo 'Third case, return instead of break';
+        return;
+    default:
+        echo 'Default case';
+        break;
+}
+SAME AS PSR2
+-->
+
+<!-- 5.3. while, do while
+
+A while statement looks like the following. Note the placement of parentheses, spaces, and braces.
+<?php
+while ($expr) {
+    // structure body
+}
+Similarly, a do while statement looks like the following. Note the placement of parentheses, spaces, and braces.
+<?php
+do {
+    // structure body;
+} while ($expr);
+SAME AS PSR2
+-->
+
+
+<!-- 5.4. for
+
+A for statement looks like the following. Note the placement of parentheses, spaces, and braces.
+<?php
+for ($i = 0; $i < 10; $i++) {
+    // for body
+}
+SAME AS PSR2
+-->
+
+<!-- 5.5. foreach
+
+A foreach statement looks like the following. Note the placement of parentheses, spaces, and braces.
+<?php
+foreach ($iterable as $key => $value) {
+    // foreach body
+}
+SAME AS PSR2
+
+
+Avoid the use of $k, $v, $key, $value etc. for variables within a foreach, names SHOULD be descriptive.
+@TODO - Kent Rule - need custom config??
+-->
+
+
+<!-- 5.6. try, catch
+
+A try catch block looks like the following. Note the placement of parentheses, spaces, and braces.
+<?php
+try {
+    // try body
+} catch (FirstExceptionType $e) {
+    // catch body
+} catch (OtherExceptionType $e) {
+    // catch body
+}
+SAME AS PSR2
+-->
+
+<!-- 5.7. Ternary statements
+
+Ternary statments MUST NOT be nested. Use other approriate control structues nested with correct indentation.
+
+There MUST be one space both before and after the ? and : in a ternary expresion. ?: is permited when ther is no `true' case.
+
+There MUST be braces surrounding the condition if it contains any form of expression, i.e. is not simply a variable or boolean.
+@TODO - Kent Rule - need custom config??
+-->
+
+
+<!-- Closures
+Closures MUST be declared with a space after the function keyword, and a space before and after the use keyword.
+
+The opening brace MUST go on the same line, and the closing brace MUST go on the next line following the body.
+
+There MUST NOT be a space after the opening parenthesis of the argument list or variable list, and there MUST NOT be a space before the closing parenthesis of the argument list or variable list.
+
+In the argument list and variable list, there MUST NOT be a space before each comma, and there MUST be one space after each comma.
+
+Closure arguments with default values MUST go at the end of the argument list.
+
+A closure declaration looks like the following. Note the placement of parentheses, commas, spaces, and braces:
+
+<?php
+$closureWithArgs = function ($arg1, $arg2) {
+    // body
+};
+
+$closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2) {
+    // body
+};
+Argument lists and variable lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument or variable per line.
+
+When the ending list (whether or arguments or variables) is split across multiple lines, the closing parenthesis and opening brace MUST be placed together on their own line with one space between them.
+
+The following are examples of closures with and without argument lists and variable lists split across multiple lines.
+
+<?php
+$longArgs_noVars = function (
+    $longArgument,
+    $longerArgument,
+    $muchLongerArgument
+) {
+   // body
+};
+
+$noArgs_longVars = function () use (
+    $longVar1,
+    $longerVar2,
+    $muchLongerVar3
+) {
+   // body
+};
+
+$longArgs_longVars = function (
+    $longArgument,
+    $longerArgument,
+    $muchLongerArgument
+) use (
+    $longVar1,
+    $longerVar2,
+    $muchLongerVar3
+) {
+   // body
+};
+
+$longArgs_shortVars = function (
+    $longArgument,
+    $longerArgument,
+    $muchLongerArgument
+) use ($var1) {
+   // body
+};
+
+$shortArgs_longVars = function ($arg) use (
+    $longVar1,
+    $longerVar2,
+    $muchLongerVar3
+) {
+   // body
+};
+Note that the formatting rules also apply when the closure is used directly in a function or method call as an argument.
+<?php
+$foo->bar(
+    $arg1,
+    function ($arg2) use ($var1) {
+        // body
+    },
+    $arg3
+);
+SAME AS PSR2
 -->

--- a/phpcs/kent-coding-standard.xml
+++ b/phpcs/kent-coding-standard.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+<ruleset name="Kent Standard">
+<!-- phpcs rule set based on https://github.com/unikent/KentStandards 
+codesniffer ruleset by Christian Cable c.f.cable@kent.ac.uk
+corrections to help it match the standard are more than welcome
+-->
+
+<!-- PSR2 -->
+<rule ref="PSR2">
+<exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
+</rule>
+
+<!-- 1.1. PHP Tags
+PHP code MUST use the long <?php ?> tags it MUST NOT use the short-echo <?= ?> tags or other tag variations. 
+
+@TODO - need custom config
+-->
+
+<!-- 1.2. Character Encoding
+PHP code MUST use only UTF-8 without BOM.
+
+@TODO - need custom config
+-->
+
+<!-- 1.3. Line Endings
+All PHP files SHOULD use use the Unix LF (linefeed) line ending. Whatever line ending is used it MUST be used consitently throughout a project.
+
+SAME AS PSR2
+-->
+
+
+<!-- 1.4. Whitespace & Indentation
+
+All PHP files MUST end with a single blank line.
+
+SAME AS PSR2
+-->
+
+<!-- 
+The closing ?> tag MUST be omitted from files containing only PHP.
+
+SAME AS PSR2
+-->
+
+<!-- 
+There MUST NOT be trailing whitespace at the end of non-blank lines.
+
+SAME AS PSR2
+-->
+
+<!-- 
+Single blank lines MAY be added to improve readability and to indicate related blocks of code.
+SAME AS PSR2
+-->
+
+<!--
+Code MUST use tabs for indentation, and MUST NOT use spaces for indenting.
+The use of spaces is permitted for fine-grained inter-line alignment of operators, values etc.
+Kent Rule
+-->
+<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+</ruleset>
+
+
+
+<!--  1.5. Lines
+
+There MUST NOT be more than one statement per line.
+SAME AS PSR2
+
+There MUST NOT be a hard limit on line length.
+SAME AS PSR2
+
+The soft limit on line length MUST be 120 characters; automated style checkers MUST warn but MUST NOT error at the soft limit.
+SAME AS PSR2
+
+Lines SHOULD NOT be longer than 80 characters; lines longer than that SHOULD be split into multiple subsequent lines of no more than 80 characters each.
+SAME AS PSR2
+-->
+
+
+<!-- 1.6. Keywords and True/False/Null
+
+PHP keywords MUST be in lower case.
+SAME AS PSR2
+
+The PHP constants true, false, and null MUST be in lower case.
+SAME AS PSR2
+-->
+
+<!-- 1.7. Side Effects
+A file SHOULD declare new symbols (classes, functions, constants, etc.) and cause no other side effects, 
+or it SHOULD execute logic with side effects, but SHOULD NOT do both.
+SAME AS PSR2 (defined in PSR1) 
+-->
+
+
+
+<!--  Namespace, Use Declarations and Class Names
+Namespaces and classes MUST follow PSR-4 "autoloading". This means each class is in a file by itself, 
+and is in a namespace of at least one level: a top-level vendor name.
+
+When present, there MUST be one blank line after the namespace declaration.
+
+When present, all use declarations MUST go after the namespace declaration.
+
+There MUST be one use keyword per declaration.
+
+There MUST be one blank line after the use block.
+-->

--- a/phpcs/kentStandard/Sniffs/DisallowGenericVariableNamesInForEachLoopSniff.php
+++ b/phpcs/kentStandard/Sniffs/DisallowGenericVariableNamesInForEachLoopSniff.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * This sniff disallows the use of generic varible names in a foreach loop
+ * inspired by the the Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff sniff
+ *
+ * this implements a check for 5.5 rule:
+ * Avoid the use of $k, $v, $key, $value etc. for variables within a foreach, names SHOULD be descriptive
+ *
+ * @author Christian Cable <c.f.cable@kent.ac.uk>
+ *
+ */
+namespace kentStandard\sniffs;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class DisallowGenericVariableNamesInForEachLoop implements Sniff
+{
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register()
+	{
+		return array(T_FOREACH);
+	}//end register()
+
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token in the
+	 *                                               stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process(File $phpcsFile, $stackPtr)
+	{
+		$tokens = $phpcsFile->getTokens();
+
+		$openingBracketPtr = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr);
+		if ($openingBracketPtr === false) {
+			$error = 'Possible parse error: FOREACH has no opening parenthesis';
+			$phpcsFile->addWarning($error, $stackPtr, 'MissingOpenParenthesis');
+			return;
+		}
+		
+		if (isset($tokens[$openingBracketPtr]['parenthesis_closer']) === false) {
+			$error = 'Possible parse error: FOREACH has no closing parenthesis';
+			$phpcsFile->addWarning($error, $stackPtr, 'MissingCloseParenthesis');
+			return;
+		}
+
+		$closingBracketPtr = $tokens[$openingBracketPtr]['parenthesis_closer'];
+
+
+		for ($currentTokenPtr=$openingBracketPtr; $currentTokenPtr != $closingBracketPtr; $currentTokenPtr++) {
+			if ($tokens[$currentTokenPtr]['type'] == 'T_VARIABLE') {
+				$error = 'Avoid the use of $k, $v, $key, $value etc. for variables within a foreach, names SHOULD be descriptive. Found %s';
+				$variable = $tokens[$currentTokenPtr]['content'];
+			
+				// assuming single character vars are not descriptive
+				if (strlen($variable) <= 2) {
+					$phpcsFile->addWarning($error, $currentTokenPtr, 'GenericVariableNamesInForEachLoop', $variable);
+				}
+
+				// check for generic variable names
+				$genericNames = ['$value', '$key'];
+				if (in_array($variable, $genericNames)) {
+					$phpcsFile->addWarning($error, $currentTokenPtr, 'GenericVariableNamesInForEachLoop', $variable);
+				}
+			}
+		}
+	}
+}

--- a/phpcs/kentStandard/ruleset.xml
+++ b/phpcs/kentStandard/ruleset.xml
@@ -342,7 +342,7 @@ SAME AS PSR2
 
 
 Avoid the use of $k, $v, $key, $value etc. for variables within a foreach, names SHOULD be descriptive.
-@TODO - Kent Rule - need custom config??
+CUSTOM RULE - DisallowGenericVariableNamesInForEachLoopSniff
 -->
 
 

--- a/phpcs/kentStandard/ruleset.xml
+++ b/phpcs/kentStandard/ruleset.xml
@@ -5,11 +5,11 @@ codesniffer ruleset by Christian Cable c.f.cable@kent.ac.uk
 corrections to help it match the standard are more than welcome
 -->
 
- <description>PHP Coding Standard for The University of Kent</description>
+<description>PHP Coding Standard for The University of Kent</description>
 
 <!-- PSR2 -->
 <rule ref="PSR2">
-<exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
+    <exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
 </rule>
 
 <!-- 1.1. PHP Tags
@@ -28,7 +28,6 @@ PHP code MUST use only UTF-8 without BOM.
 
 <!-- 1.3. Line Endings
 All PHP files SHOULD use use the Unix LF (linefeed) line ending. Whatever line ending is used it MUST be used consitently throughout a project.
-
 SAME AS PSR2
 -->
 

--- a/phpcs/kentStandard/ruleset.xml
+++ b/phpcs/kentStandard/ruleset.xml
@@ -363,7 +363,7 @@ SAME AS PSR2
 
 <!-- 5.7. Ternary statements
 
-Ternary statments MUST NOT be nested. Use other approriate control structues nested with correct indentation.
+Ternary statements MUST NOT be nested. Use other approriate control structues nested with correct indentation.
 
 There MUST be one space both before and after the ? and : in a ternary expresion. ?: is permited when ther is no `true' case.
 

--- a/phpcs/kentStandard/ruleset.xml
+++ b/phpcs/kentStandard/ruleset.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0"?>
-<ruleset name="Kent Standard">
+<ruleset name="KentStandard">
 <!-- phpcs rule set based on https://github.com/unikent/KentStandards 
 codesniffer ruleset by Christian Cable c.f.cable@kent.ac.uk
 corrections to help it match the standard are more than welcome
 -->
+
+ <description>PHP Coding Standard for The University of Kent</description>
 
 <!-- PSR2 -->
 <rule ref="PSR2">
@@ -12,8 +14,12 @@ corrections to help it match the standard are more than welcome
 
 <!-- 1.1. PHP Tags
 PHP code MUST use the long <?php ?> tags it MUST NOT use the short-echo <?= ?> tags or other tag variations. 
-@TODO - need custom config
+
+NOTE - if the local php doesn't have short tags enabled then this rules isn't even run because code surrounded by short tags
+isn't even considered php...
 -->
+<rule ref="Generic.PHP.DisallowShortOpenTag"/>
+
 
 <!-- 1.2. Character Encoding
 PHP code MUST use only UTF-8 without BOM.
@@ -46,11 +52,12 @@ SAME AS PSR2
 
 Code MUST use tabs for indentation, and MUST NOT use spaces for indenting.
 The use of spaces is permitted for fine-grained inter-line alignment of operators, values etc.
-@TODO - Kent Rule - need custom config??
-
 -->
-<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
-</ruleset>
+<rule ref="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed">
+  <message>Code MUST use tabs for indentation, and MUST NOT use spaces for indenting. The use of spaces is permitted for fine-grained inter-line alignment of operators, values etc.</message>
+</rule>
+
+
 
 
 
@@ -89,7 +96,7 @@ SAME AS PSR2 (defined in PSR1)
 <!--  2 Namespace, Use Declarations and Class Names
 Namespaces and classes MUST follow PSR-4 "autoloading". This means each class is in a file by itself, 
 and is in a namespace of at least one level: a top-level vendor name.
-@TODO - Kent Rule - need custom config??
+SAME AS PSR2
 
 
 When present, there MUST be one blank line after the namespace declaration.
@@ -116,7 +123,7 @@ SAME AS PSR2 (defined in PSR1)
 
 
 Code written for 5.2.x and before SHOULD use the pseudo-namespacing convention of Vendor_ prefixes on class names.
-@TODO - Kent Rule - need custom config??
+SAME AS PSR2 (defined in PSR1)
 
 The extends and implements keywords MUST be declared on the same line as the class name.
 SAME AS PSR2
@@ -447,3 +454,4 @@ $foo->bar(
 );
 SAME AS PSR2
 -->
+</ruleset>


### PR DESCRIPTION
this adds a phpcs ruleset which implements most of the standards and can be used by phpcs as well as a number of coding editors. 